### PR TITLE
fixbug auth failed when password has special charsets

### DIFF
--- a/src/Provider/AuthProvider.php
+++ b/src/Provider/AuthProvider.php
@@ -21,9 +21,11 @@ class AuthProvider extends AbstractProvider
     {
         return $this->client()->request('POST', '/nacos/v1/auth/users/login', [
             RequestOptions::QUERY => [
-                'username' => $username,
-                'password' => $password,
+                'username' => $username
             ],
+            RequestOptions::FORM_PARAMS => [
+                "password" => $password
+            ]
         ]);
     }
 }


### PR DESCRIPTION
当密码中包含特殊字符时，nacos登录失败。

原因是将password放在query params中，会自动url_encode。
将password放在body中，则特殊字符不会被url_encode。