### PR TITLE
Fixd: Nacos config center not returning encryptedDataKey when config encryption is disabled

### DIFF
--- a/src/Protobuf/Response/ConfigQueryResponse.php
+++ b/src/Protobuf/Response/ConfigQueryResponse.php
@@ -29,7 +29,7 @@ class ConfigQueryResponse extends Response
     public function __construct(array $json)
     {
         $this->content = $json['content'];
-        $this->encryptedDataKey = $json['encryptedDataKey'];
+        $this->encryptedDataKey = $json['encryptedDataKey'] ?? '';
         $this->contentType = $json['contentType'];
         $this->md5 = $json['md5'];
         $this->lastModified = $json['lastModified'];


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3e02df47-c95e-4436-ba71-f94f94ff4e27)


nacos版本: 2.5.1